### PR TITLE
We should avoid yaml.load in general

### DIFF
--- a/sharder/daemon.py
+++ b/sharder/daemon.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
   config = default_config()
   if args.config_file is not None:
     with open(args.config_file) as f:
-      c = yaml.load(f)
+      c = yaml.safe_load(f)
       config.update(c)
 
   cookie_secret = os.environ.get('COOKIE_SECRET')


### PR DESCRIPTION
This now throws an error PyYaml 6.0 but the alternative `safe_load` is
also available in the oldest version we have deployed so let's just
update this.

Signed-off-by: Ian Allison <iana@pims.math.ca>