### PR TITLE
Allow bucket count to be modified by configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,39 +11,11 @@ services:
   sharder:
     build: ./sharder
     container_name: sharder
+    volumes:
+      #- /Users/iana/sharder/sharder.yml:/srv/sharder/sharder.yml:ro
+      - /Users/iana/sharder/sharder.yml:/srv/sharder/sharder.yml:ro
     ports:
       - "8888:8888"
     environment:
-      - DB_TYPE=mysql+pymysql
-      - DB_USER=${POSTGRES_USER}
-      - DB_PASSWORD=${POSTGRES_PASSWORD}
-      - DB_NAME=${POSTGRES_DB}
-      - DB_HOST=mysql
-    depends_on:
-      - postgres
-      - mysql
+      - DB_TYPE=sqlite
 
-  postgres:
-    image: postgres
-    container_name: postgres
-    volumes:
-      - ./db/postgres:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
-
-  mysql:
-    image: mysql
-    container_name: mysql
-    volumes:
-      - ./db/mysql:/var/lib/mysql
-    ports:
-      - "3306:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_DATABASE=${MYSQL_DATABASE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       #- /Users/iana/sharder/sharder.yml:/srv/sharder/sharder.yml:ro
       - /Users/iana/sharder/sharder.yml:/srv/sharder/sharder.yml:ro
+      - /Users/iana/sharder/sharder.db:/srv/sharder/sharder.db
     ports:
       - "8888:8888"
     environment:

--- a/sharder.yml.example
+++ b/sharder.yml.example
@@ -1,0 +1,10 @@
+db_file: ./sharder.db
+db_type: sqlite
+domain: callysto.ca
+hubs:
+  - name: hub-01.callysto.ca
+  - name: hub-02.callysto.ca
+    extra_shards: 403
+  - name: hub-03.callysto.ca
+    extra_shards: 403
+sharder_listen: 0.0.0.0

--- a/sharder/Dockerfile
+++ b/sharder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-stretch
+FROM python:3.9-slim
 
 MAINTAINER Ian Allison <iana@pims.math.ca>
 
@@ -10,16 +10,14 @@ RUN apt-get update && \
       && \
     apt-get purge && apt-get clean
 
-RUN pip3 install --no-cache-dir tornado ruamel.yaml oauthlib psycopg2-binary pycurl sqlalchemy pyyaml pymysql cryptography
+RUN pip3 install --no-cache-dir tornado ruamel.yaml oauthlib psycopg2-binary pycurl "sqlalchemy<2" pyyaml pymysql cryptography
 
 RUN mkdir -p /srv/sharder
-ADD db.py /srv/sharder/db.py
 ADD sharder.py /srv/sharder/sharder.py
 ADD daemon.py /srv/sharder/daemon.py
-ADD wait-for-it.sh /srv/sharder/wait-for-it.sh
-RUN chmod +x /srv/sharder/wait-for-it.sh
+ADD utils.py /srv/sharder/utils.py
 ADD templates /srv/sharder/templates
 
 WORKDIR /srv/sharder
 
-ENTRYPOINT ["/srv/sharder/wait-for-it.sh", "-t", "60", "mysql:3306", "--", "python3.6", "/srv/sharder/daemon.py"]
+ENTRYPOINT ["python3", "/srv/sharder/daemon.py", "--config-file", "/srv/sharder/sharder.yml"]

--- a/sharder/Dockerfile
+++ b/sharder/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /srv/sharder
 ADD sharder.py /srv/sharder/sharder.py
 ADD daemon.py /srv/sharder/daemon.py
 ADD utils.py /srv/sharder/utils.py
+ADD admin.py /srv/sharder/admin.py
 ADD templates /srv/sharder/templates
 
 WORKDIR /srv/sharder

--- a/sharder/admin.py
+++ b/sharder/admin.py
@@ -53,10 +53,23 @@ def list_hubs():
     .filter(Shard.kind == 'hub')
     .group_by(Shard.bucket)
     .order_by('bucket'))
+ 
+  hub_counts = {}
+  for hub in sharder.hubs:
+    hub_counts[hub['name']] = {'extra_shards' : hub.get("extra_shards", 0) }
 
-  print("{: <45} {: <30}".format("Hub", "Total Users"))
   for hub in q:
-    print("{: <45} {: <30}".format(hub.bucket, hub.total-1))
+    hub_counts[hub.bucket]['raw'] = hub.total
+
+  print("{: <35} {: <10} {: <10} {: <20}".format("Hub", "Raw", "Extra", "Effective Total Users"))
+  for hub, hubinfo in hub_counts.items():
+      print("{: <35} {: <10} {: < 10} {: <10}".format(
+        hub,
+        hubinfo['raw'],
+        hubinfo['extra_shards'],
+        hubinfo['raw'] + hubinfo['extra_shards']
+      )
+    )
 
 def move_user():
   q = sharder.session.query(Shard).filter(

--- a/sharder/admin.py
+++ b/sharder/admin.py
@@ -12,157 +12,179 @@ from utils import default_config, configure_database, create_sharder
 
 
 def list_users():
-  q = sharder.session.query(Shard).filter(Shard.kind == 'hub')
-  print("{: <45} {: <30}".format("Username", "Hub"))
-  for user in q:
-    if 'dummy-' in user.name:
-      continue
-    print("{: <45} {: <30}".format(user.name, user.bucket))
+    q = sharder.session.query(Shard).filter(Shard.kind == "hub")
+    print("{: <45} {: <30}".format("Username", "Hub"))
+    for user in q:
+        if "dummy-" in user.name:
+            continue
+        print("{: <45} {: <30}".format(user.name, user.bucket))
+
 
 def find_user():
-  q = sharder.session.query(Shard).filter(
-      Shard.kind == 'hub', Shard.name == args.find_user)
-  print("{: <45} {: <30}".format("Username", "Hub"))
-  for user in q:
-    print("{: <45} {: <30}".format(user.name, user.bucket))
+    q = sharder.session.query(Shard).filter(
+        Shard.kind == "hub", Shard.name == args.find_user
+    )
+    print("{: <45} {: <30}".format("Username", "Hub"))
+    for user in q:
+        print("{: <45} {: <30}".format(user.name, user.bucket))
+
 
 def delete_user():
-  q = sharder.session.query(Shard).filter(
-      Shard.kind == 'hub', Shard.name == args.delete_user)
-
-  if q.count() != 1:
-    print(f"Could not find user {args.delete_user}")
-    sys.exit(1)
-
-  user = q[0]
-  sharder.session.delete(user)
-  sharder.session.commit()
-
-def list_users_on_hub():
-  q = sharder.session.query(Shard).filter(
-      Shard.kind == 'hub', Shard.bucket == args.list_users_on_hub)
-  print("{: <45} {: <30}".format("Username", "Hub"))
-  for user in q:
-    if 'dummy-' in user.name:
-      continue
-    print("{: <45} {: <30}".format(user.name, user.bucket))
-
-def list_hubs():
-  q = (sharder.session.query(Shard.bucket, func.count(Shard.bucket)
-    .label('total'))
-    .filter(Shard.kind == 'hub')
-    .group_by(Shard.bucket)
-    .order_by('bucket'))
- 
-  hub_counts = {}
-  for hub in sharder.hubs:
-    hub_counts[hub['name']] = {'extra_shards' : hub.get("extra_shards", 0) }
-
-  for hub in q:
-    hub_counts[hub.bucket]['raw'] = hub.total
-
-  print("{: <35} {: <10} {: <10} {: <20}".format("Hub", "Raw", "Extra", "Effective Total Users"))
-  for hub, hubinfo in hub_counts.items():
-      print("{: <35} {: <10} {: < 10} {: <10}".format(
-        hub,
-        hubinfo['raw'],
-        hubinfo['extra_shards'],
-        hubinfo['raw'] + hubinfo['extra_shards']
-      )
+    q = sharder.session.query(Shard).filter(
+        Shard.kind == "hub", Shard.name == args.delete_user
     )
 
+    if q.count() != 1:
+        print(f"Could not find user {args.delete_user}")
+        sys.exit(1)
+
+    user = q[0]
+    sharder.session.delete(user)
+    sharder.session.commit()
+
+
+def list_users_on_hub():
+    q = sharder.session.query(Shard).filter(
+        Shard.kind == "hub", Shard.bucket == args.list_users_on_hub
+    )
+    print("{: <45} {: <30}".format("Username", "Hub"))
+    for user in q:
+        if "dummy-" in user.name:
+            continue
+        print("{: <45} {: <30}".format(user.name, user.bucket))
+
+
+def list_hubs():
+    q = (
+        sharder.session.query(Shard.bucket, func.count(Shard.bucket).label("total"))
+        .filter(Shard.kind == "hub")
+        .group_by(Shard.bucket)
+        .order_by("bucket")
+    )
+
+    hub_counts = {}
+    for hub in sharder.hubs:
+        hub_counts[hub["name"]] = {"extra_shards": hub.get("extra_shards", 0)}
+
+    for hub in q:
+        hub_counts[hub.bucket]["raw"] = hub.total
+
+    print(
+        "{: <35} {: <10} {: <10} {: <20}".format(
+            "Hub", "Raw", "Extra", "Effective Total Users"
+        )
+    )
+    for hub, hubinfo in hub_counts.items():
+        print(
+            "{: <35} {: <10} {: < 10} {: <10}".format(
+                hub,
+                hubinfo["raw"],
+                hubinfo["extra_shards"],
+                hubinfo["raw"] + hubinfo["extra_shards"],
+            )
+        )
+
+
 def move_user():
-  q = sharder.session.query(Shard).filter(
-      Shard.kind == 'hub', Shard.name == args.move_user)
+    q = sharder.session.query(Shard).filter(
+        Shard.kind == "hub", Shard.name == args.move_user
+    )
 
-  if q.count() != 1:
-    print(f"Could not find user {args.move_user}")
-    sys.exit(1)
+    if q.count() != 1:
+        print(f"Could not find user {args.move_user}")
+        sys.exit(1)
 
-  user = q[0]
+    user = q[0]
 
-  if args.to_hub not in config['hubs']:
-    print(f"Could not find hub {args.to_hub}")
-    sys.exit(1)
+    if args.to_hub not in config["hubs"]:
+        print(f"Could not find hub {args.to_hub}")
+        sys.exit(1)
 
-  user.bucket = args.to_hub
-  sharder.session.commit()
-
-def add_user():
-  if args.to_hub not in config['hubs']:
-    print(f"Count not find hub {args.to_hub}")
-    sys.exit(1)
-
-  sharder.session.add(Shard(kind='hub', bucket=args.to_hub, name=args.add_user))
-  sharder.session.commit()
-
-def migrate_hub():
-  if args.migrate_hub not in config['hubs']:
-    print(f"Could not find hub {args.migrate_hub}")
-    sys.exit(1)
-
-  if args.to_hub not in config['hubs']:
-    print(f"Could not find hub {args.to_hub}")
-    sys.exit(1)
-
-  q = sharder.session.query(Shard).filter(
-      Shard.kind == 'hub', Shard.bucket == args.migrate_hub)
-
-  for user in q:
     user.bucket = args.to_hub
     sharder.session.commit()
 
 
+def add_user():
+    if args.to_hub not in config["hubs"]:
+        print(f"Count not find hub {args.to_hub}")
+        sys.exit(1)
+
+    sharder.session.add(Shard(kind="hub", bucket=args.to_hub, name=args.add_user))
+    sharder.session.commit()
+
+
+def migrate_hub():
+    if args.migrate_hub not in config["hubs"]:
+        print(f"Could not find hub {args.migrate_hub}")
+        sys.exit(1)
+
+    if args.to_hub not in config["hubs"]:
+        print(f"Could not find hub {args.to_hub}")
+        sys.exit(1)
+
+    q = sharder.session.query(Shard).filter(
+        Shard.kind == "hub", Shard.bucket == args.migrate_hub
+    )
+
+    for user in q:
+        user.bucket = args.to_hub
+        sharder.session.commit()
+
+
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='JupyterHub Sharder Admin Utility')
-  parser.add_argument('--config-file', help="The sharder config file", default="/srv/sharder/sharder.yml")
-  parser.add_argument('--find-user', help="Find a user by <user>")
-  parser.add_argument('--add-user', help="Add <user>")
-  parser.add_argument('--delete-user', help="Delete <user>")
-  parser.add_argument('--list-users-on-hub', help="List all users on <hub>")
-  parser.add_argument('--list-hubs', action='store_true', help="List all hubs")
-  parser.add_argument('--list-users', action='store_true', help="List all users")
-  parser.add_argument('--move-user', help="Move <user>")
-  parser.add_argument('--migrate-hub', help="Move all users on <hub>")
-  parser.add_argument('--to-hub', help="Destination <hub> for adds and moves")
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="JupyterHub Sharder Admin Utility")
+    parser.add_argument(
+        "--config-file",
+        help="The sharder config file",
+        default="/srv/sharder/sharder.yml",
+    )
+    parser.add_argument("--find-user", help="Find a user by <user>")
+    parser.add_argument("--add-user", help="Add <user>")
+    parser.add_argument("--delete-user", help="Delete <user>")
+    parser.add_argument("--list-users-on-hub", help="List all users on <hub>")
+    parser.add_argument("--list-hubs", action="store_true", help="List all hubs")
+    parser.add_argument("--list-users", action="store_true", help="List all users")
+    parser.add_argument("--move-user", help="Move <user>")
+    parser.add_argument("--migrate-hub", help="Move all users on <hub>")
+    parser.add_argument("--to-hub", help="Destination <hub> for adds and moves")
+    args = parser.parse_args()
 
-  l = log.app_log
-  config = default_config()
-  if args.config_file is not None:
-    with open(args.config_file) as f:
-      c = yaml.load(f, Loader=yaml.FullLoader)
-      config.update(c)
+    l = log.app_log
+    config = default_config()
+    if args.config_file is not None:
+        with open(args.config_file) as f:
+            c = yaml.load(f, Loader=yaml.FullLoader)
+            config.update(c)
 
-  db = configure_database(config, l)
-  sharder = create_sharder(config, db, l)
+    db = configure_database(config, l)
+    sharder = create_sharder(config, db, l)
 
-  if args.find_user:
-    find_user()
+    if args.find_user:
+        find_user()
 
-  if args.list_users:
-    list_users()
+    if args.list_users:
+        list_users()
 
-  if args.list_users_on_hub:
-    list_users_on_hub()
+    if args.list_users_on_hub:
+        list_users_on_hub()
 
-  if args.list_hubs:
-    list_hubs()
+    if args.list_hubs:
+        list_hubs()
 
-  if args.delete_user:
-    delete_user()
+    if args.delete_user:
+        delete_user()
 
-  if args.add_user:
-    add_user()
+    if args.add_user:
+        add_user()
 
-  if args.move_user:
-    if args.to_hub is None:
-      print("--move-user requires --to-hub")
-      sys.exit(1)
-    move_user()
+    if args.move_user:
+        if args.to_hub is None:
+            print("--move-user requires --to-hub")
+            sys.exit(1)
+        move_user()
 
-  if args.migrate_hub:
-    if args.to_hub is None:
-      print("--move-all-users-on requires --to-hub")
-      sys.exit(1)
-    migrate_hub()
+    if args.migrate_hub:
+        if args.to_hub is None:
+            print("--move-all-users-on requires --to-hub")
+            sys.exit(1)
+        migrate_hub()

--- a/sharder/requirements.txt
+++ b/sharder/requirements.txt
@@ -5,5 +5,5 @@ pycurl
 pymysql
 pyyaml
 ruamel.yaml
-sqlalchemy
+sqlalchemy<2
 tornado

--- a/sharder/sharder.py
+++ b/sharder/sharder.py
@@ -2,8 +2,7 @@ import tornado.web
 
 from sqlalchemy import func
 from sqlalchemy import Column, Integer, String, UniqueConstraint, Index
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 
 DBBase = declarative_base()

--- a/sharder/sharder.py
+++ b/sharder/sharder.py
@@ -74,20 +74,20 @@ class Sharder:
         for row in rows:
             buckets[row[0]] = row[1]
 
-        # If a hub has an offset defined, act as if the offset was added
-        # to the total bucket count
-        offsets = {}
+        # If a hub has extra_shards defined, act as if they have been
+        # added to the bucket count
+        extra_shards = {}
         for hub in self.hubs:
-            offsets[hub['name']] = hub.get('offset', 0)
+            extra_shards[hub['name']] = hub.get('extra_shards', 0)
 
         for b, c in buckets.items():
-            buckets[b] = c + offsets[b]
+            buckets[b] = c + extra_shards[b]
         
         # Assign to least used
         bucket = min(buckets, key=buckets.get)
         if bucket:
             self.session.add(Shard(kind=self.kind, bucket=bucket, name=name))
-            self.log.info(f'Assigned {name} to bucket {bucket}')
+            self.log.info(f'Assigned {name} to bucket {bucket} (effective count : {buckets})')
             self.session.commit()
 
         return bucket

--- a/sharder/sharder.py
+++ b/sharder/sharder.py
@@ -45,7 +45,7 @@ class Sharder:
 
         # Make sure that we have at least one dummy entry for each bucket
         # NOTE: This is rather poor SQL design, but we'll defer that until later.
-        for bucket in buckets:
+        for bucket in self.buckets:
             if self.session.query(Shard.bucket).filter_by(bucket=bucket, name=f'dummy-{bucket}').scalar() is None:
                 self.session.add(Shard(kind=self.kind, bucket=bucket, name=f'dummy-{bucket}'))
                 self.session.commit()

--- a/sharder/sharder.py
+++ b/sharder/sharder.py
@@ -1,5 +1,7 @@
+import json
 import tornado.web
 
+from collections import Counter
 from sqlalchemy import func
 from sqlalchemy import Column, Integer, String, UniqueConstraint, Index
 from sqlalchemy.orm import declarative_base, sessionmaker
@@ -7,20 +9,22 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 
 DBBase = declarative_base()
 
+
 class Shard(DBBase):
     """
     Sharding table
     """
+
     __tablename__ = "shard"
-    id     = Column(Integer, autoincrement=True, primary_key=True)
-    kind   = Column(String(256))
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    kind = Column(String(256))
     bucket = Column(String(256))
-    name   = Column(String(256))
+    name = Column(String(256))
     UniqueConstraint(kind, name)
-    Index('shard_kind_name_index', kind, name)
+    Index("shard_kind_name_index", kind, name)
 
     def __repr__(self):
-        return f'<User(id={self.id}, kind={self.kind}, bucket={self.bucket}, name={self.name})>'
+        return f"<User(id={self.id}, kind={self.kind}, bucket={self.bucket}, name={self.name})>"
 
 
 class Sharder:
@@ -30,11 +34,12 @@ class Sharder:
     across multiple buckets, ensuring that once an object is assigned to a bucket it always
     is assigned to the same bucket.
     """
+
     def __init__(self, engine, kind, hubs, log):
-        self.engine  = engine
-        self.kind    = kind
-        self.hubs    = hubs
-        self.log     = log
+        self.engine = engine
+        self.kind = kind
+        self.hubs = hubs
+        self.log = log
 
         DBBase.metadata.create_all(engine, checkfirst=True)
 
@@ -45,9 +50,52 @@ class Sharder:
         # Make sure that we have at least one dummy entry for each bucket
         # NOTE: This is rather poor SQL design, but we'll defer that until later.
         for hub in self.hubs:
-            if self.session.query(Shard.bucket).filter_by(bucket=hub['name'], name=f"dummy-{hub['name']}").scalar() is None:
-                self.session.add(Shard(kind=self.kind, bucket=hub['name'], name=f"dummy-{hub['name']}"))
+            if (
+                self.session.query(Shard.bucket)
+                .filter_by(bucket=hub["name"], name=f"dummy-{hub['name']}")
+                .scalar()
+                is None
+            ):
+                self.session.add(
+                    Shard(
+                        kind=self.kind, bucket=hub["name"], name=f"dummy-{hub['name']}"
+                    )
+                )
                 self.session.commit()
+
+    def _bucket_count(self, extras=False):
+        rows = (
+            self.session.query(Shard.bucket, func.count(Shard.bucket).label("total"))
+            .filter(Shard.kind == self.kind)
+            .group_by(Shard.bucket)
+            .order_by("total")
+            .all()
+        )
+        buckets = {}
+        for row in rows:
+            buckets[row[0]] = row[1]
+
+        if extras:
+            extra_shards = {}
+            for hub in self.hubs:
+                extra_shards[hub["name"]] = hub.get("extra_shards", 0)
+
+            for b, c in buckets.items():
+                buckets[b] = c + extra_shards[b]
+
+        return buckets
+
+    def __str__(self):
+        buckets_raw = Counter(self._bucket_count())
+        buckets_extra = Counter(self._bucket_count(extras=True))
+
+        extras = buckets_extra - buckets_raw
+
+        buckets_str = {}
+        for b, c in buckets_raw.items():
+            buckets_str[b] = f"{buckets_raw[b]}+{extras[b]}={buckets_extra[b]}"
+
+        return json.dumps(buckets_str)
 
     def shard(self, name):
         """
@@ -55,38 +103,23 @@ class Sharder:
         If it isn't already in the database, a new entry will be created in the
         least populated bucket.
         """
-        q = self.session.query(Shard).filter(Shard.kind == self.kind, Shard.name == name).first()
+        q = (
+            self.session.query(Shard)
+            .filter(Shard.kind == self.kind, Shard.name == name)
+            .first()
+        )
         if q:
             bucket = q.bucket
-            self.log.info(f'Found {name} sharded into bucket {bucket}')
+            self.log.info(f"Found {name} sharded into bucket {bucket}")
             return bucket
 
-        # name isn't assigned to a bucket yet, add an entry
-        rows = (self.session.query(Shard.bucket, func.count(Shard.bucket)
-            .label('total'))
-            .filter(Shard.kind == self.kind)
-            .group_by(Shard.bucket)
-            .order_by('total').all()
-        )
-
-        buckets = {}
-        for row in rows:
-            buckets[row[0]] = row[1]
-
-        # If a hub has extra_shards defined, act as if they have been
-        # added to the bucket count
-        extra_shards = {}
-        for hub in self.hubs:
-            extra_shards[hub['name']] = hub.get('extra_shards', 0)
-
-        for b, c in buckets.items():
-            buckets[b] = c + extra_shards[b]
-        
-        # Assign to least used
+        buckets = self._bucket_count(extras=True)
         bucket = min(buckets, key=buckets.get)
         if bucket:
             self.session.add(Shard(kind=self.kind, bucket=bucket, name=name))
-            self.log.info(f'Assigned {name} to bucket {bucket} (effective count : {buckets})')
+            self.log.info(
+                f"Assigned {name} to bucket {bucket} (effective count : {buckets})"
+            )
             self.session.commit()
 
         return bucket

--- a/sharder/test_sharder.py
+++ b/sharder/test_sharder.py
@@ -5,24 +5,27 @@ from tornado import log
 
 from sharder import Sharder
 
+
 @pytest.fixture
 def engine():
-  engine = sqlalchemy.create_engine('sqlite:///:memory:')
-  return engine
+    engine = sqlalchemy.create_engine("sqlite:///:memory:")
+    return engine
+
 
 def test_single_shard(engine):
-    s = Sharder(engine, 'hub', [{'name': 'hub-1'}], log=log.app_log)
-    assert s.shard('user') == 'hub-1'
+    s = Sharder(engine, "hub", [{"name": "hub-1"}], log=log.app_log)
+    assert s.shard("user") == "hub-1"
+
 
 def test_multiple_equal_shards(engine):
     """
     Check that we shard entries equally across buckets. If we have 10 buckets
     and 100 entries, each buckets should see 10 shards
     """
-    buckets = [{'name': str(i)} for i in range(10)]
-    entries = [str(i) for i in range(100)]
+    buckets = [{"name": f"hub-{str(i)}"} for i in range(10)]
+    entries = [f"user-{str(i)}" for i in range(100)]
 
-    s = Sharder(engine, 'hub', buckets, log=log.app_log)
+    s = Sharder(engine, "hub", buckets, log=log.app_log)
     [s.shard(e) for e in entries]
 
     shards = {}
@@ -31,7 +34,7 @@ def test_multiple_equal_shards(engine):
         if shard in shards:
             shards[shard] += 1
         else:
-            shards[shard]  = 1
+            shards[shard] = 1
 
     assert len(shards) == 10
     assert sum(shards.values()) == 100
@@ -39,15 +42,16 @@ def test_multiple_equal_shards(engine):
     for shard, count in shards.items():
         assert count == 10
 
+
 def test_multiple_unequal_shards(engine):
     """
     Check that when the number of entries isn't divisible by the number of
     buckets we still shard as fairly as possible.
     """
-    buckets = [{'name': str(i)} for i in range(10)]
-    entries = [str(i) for i in range(99)]
+    buckets = [{"name": f"hub-{str(i)}"} for i in range(10)]
+    entries = [f"user-{str(i)}" for i in range(99)]
 
-    s = Sharder(engine, 'hub', buckets, log=log.app_log)
+    s = Sharder(engine, "hub", buckets, log=log.app_log)
     [s.shard(e) for e in entries]
 
     shards = {}
@@ -62,16 +66,17 @@ def test_multiple_unequal_shards(engine):
     assert sum(shards.values()) == 99
     assert sorted(shards.values()) == [9, 10, 10, 10, 10, 10, 10, 10, 10, 10]
 
-def test_shard_with_offset(engine):
+
+def test_shard_with_extra_shards(engine):
     """
     Check that our sharding policy respects offsets. If a hub has N existing
-    entries in the database and an offset of M, it should behave as is there
-    are N - M users.
+    entries in the database and an extra_shards of M, it should behave as is there
+    are N + M users in that bucket.
     """
-    buckets = [{'name': str(i)} for i in range(10)]
-    entries = [str(i) for i in range(100)]
+    buckets = [{"name": "hub-" + str(i)} for i in range(10)]
+    entries = ["user-" + str(i) for i in range(100)]
 
-    s = Sharder(engine, 'hub', buckets, log=log.app_log)
+    s = Sharder(engine, "hub", buckets, log=log.app_log)
     [s.shard(e) for e in entries]
 
     shards = {}
@@ -80,12 +85,12 @@ def test_shard_with_offset(engine):
         if shard in shards:
             shards[shard] += 1
         else:
-            shards[shard]  = 1
+            shards[shard] = 1
 
     # Add 2 extra_shards to the first bucket.
     # The next 18 assignments should be spread evenly among the remaining hubs
-    s.hubs[0]['extra_shards'] = 2
-    extra_entries = [str(i) for i in range(100,118)]
+    s.hubs[0]["extra_shards"] = 2
+    extra_entries = ["user-" + str(i) for i in range(100, 118)]
 
     for e in extra_entries:
         shard = s.shard(e)
@@ -93,19 +98,20 @@ def test_shard_with_offset(engine):
         if shard in shards:
             shards[shard] += 1
         else:
-            shards[shard]  = 1
+            shards[shard] = 1
 
     assert len(shards) == 10
     assert sum(shards.values()) == 118
     print(shards)
+    print(s)
     for shard, count in shards.items():
-        if shard == buckets[0]['name']:
+        if shard == buckets[0]["name"]:
             assert count == 10
         else:
             assert count == 12
-   
+
     # If we assign 10 more, 1 should go to each bucket
-    extra_entries = [str(i) for i in range(118, 128)]
+    extra_entries = ["user-" + str(i) for i in range(118, 128)]
 
     for e in extra_entries:
         shard = s.shard(e)
@@ -113,13 +119,14 @@ def test_shard_with_offset(engine):
         if shard in shards:
             shards[shard] += 1
         else:
-            shards[shard]  = 1
+            shards[shard] = 1
 
     assert len(shards) == 10
     assert sum(shards.values()) == 128
     print(shards)
+    print(s)
     for shard, count in shards.items():
-        if shard == buckets[0]['name']:
+        if shard == buckets[0]["name"]:
             assert count == 11
         else:
             assert count == 13

--- a/sharder/test_sharder.py
+++ b/sharder/test_sharder.py
@@ -11,7 +11,7 @@ def engine():
   return engine
 
 def test_single_shard(engine):
-    s = Sharder(engine, 'hub', ['hub-1'], log=log.app_log)
+    s = Sharder(engine, 'hub', [{'name': 'hub-1'}], log=log.app_log)
     assert s.shard('user') == 'hub-1'
 
 def test_multiple_equal_shards(engine):
@@ -19,7 +19,7 @@ def test_multiple_equal_shards(engine):
     Check that we shard entries equally across buckets. If we have 10 buckets
     and 100 entries, each buckets should see 10 shards
     """
-    buckets = [str(i) for i in range(10)]
+    buckets = [{'name': str(i)} for i in range(10)]
     entries = [str(i) for i in range(100)]
 
     s = Sharder(engine, 'hub', buckets, log=log.app_log)
@@ -44,7 +44,7 @@ def test_multiple_unequal_shards(engine):
     Check that when the number of entries isn't divisible by the number of
     buckets we still shard as fairly as possible.
     """
-    buckets = [str(i) for i in range(10)]
+    buckets = [{'name': str(i)} for i in range(10)]
     entries = [str(i) for i in range(99)]
 
     s = Sharder(engine, 'hub', buckets, log=log.app_log)
@@ -61,3 +61,66 @@ def test_multiple_unequal_shards(engine):
     assert len(shards) == 10
     assert sum(shards.values()) == 99
     assert sorted(shards.values()) == [9, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+
+def test_shard_with_offset(engine):
+    """
+    Check that our sharding policy respects offsets. If a hub has N existing
+    entries in the database and an offset of M, it should behave as is there
+    are N - M users.
+    """
+    buckets = [{'name': str(i)} for i in range(10)]
+    entries = [str(i) for i in range(100)]
+
+    s = Sharder(engine, 'hub', buckets, log=log.app_log)
+    [s.shard(e) for e in entries]
+
+    shards = {}
+    for e in entries:
+        shard = s.shard(e)
+        if shard in shards:
+            shards[shard] += 1
+        else:
+            shards[shard]  = 1
+
+    # Add an offset of 2 to the first bucket. The next 18 hub
+    # assignments should be spread evenly among the remaining
+    # hubs
+    s.hubs[0]['offset'] = 2
+    extra_entries = [str(i) for i in range(100,118)]
+
+    for e in extra_entries:
+        shard = s.shard(e)
+        print(f"Sharded {e} as {shard}")
+        if shard in shards:
+            shards[shard] += 1
+        else:
+            shards[shard]  = 1
+
+    assert len(shards) == 10
+    assert sum(shards.values()) == 118
+    print(shards)
+    for shard, count in shards.items():
+        if shard == buckets[0]['name']:
+            assert count == 10
+        else:
+            assert count == 12
+   
+    # If we assign 10 more, 1 should go to each bucket
+    extra_entries = [str(i) for i in range(118, 128)]
+
+    for e in extra_entries:
+        shard = s.shard(e)
+        print(f"Sharded {e} as {shard}")
+        if shard in shards:
+            shards[shard] += 1
+        else:
+            shards[shard]  = 1
+
+    assert len(shards) == 10
+    assert sum(shards.values()) == 128
+    print(shards)
+    for shard, count in shards.items():
+        if shard == buckets[0]['name']:
+            assert count == 11
+        else:
+            assert count == 13

--- a/sharder/test_sharder.py
+++ b/sharder/test_sharder.py
@@ -82,10 +82,9 @@ def test_shard_with_offset(engine):
         else:
             shards[shard]  = 1
 
-    # Add an offset of 2 to the first bucket. The next 18 hub
-    # assignments should be spread evenly among the remaining
-    # hubs
-    s.hubs[0]['offset'] = 2
+    # Add 2 extra_shards to the first bucket.
+    # The next 18 assignments should be spread evenly among the remaining hubs
+    s.hubs[0]['extra_shards'] = 2
     extra_entries = [str(i) for i in range(100,118)]
 
     for e in extra_entries:

--- a/sharder/utils.py
+++ b/sharder/utils.py
@@ -82,7 +82,6 @@ def create_sharder(config, engine, log):
     if 'hubs' in config:
       hubs = config['hubs']
 
-    log.info(f'Loading hubs {hubs}')
     sharder = Sharder(engine, 'hub', hubs, log)
 
     return sharder

--- a/sharder/utils.py
+++ b/sharder/utils.py
@@ -7,17 +7,18 @@ from sqlalchemy import create_engine
 
 from sharder import Sharder
 
+
 # default_config returns a dict with the default
 # configuration values.
 def default_config():
-  c = {
-    'cookie_secret': 'THIS_IS_ONLY_FOR_TESTING',
-    'db_type': 'sqlite',
-    'sharder_port': 8888,
-    'sharder_listen': '0.0.0.0',
-  }
+    c = {
+        "cookie_secret": "THIS_IS_ONLY_FOR_TESTING",
+        "db_type": "sqlite",
+        "sharder_port": 8888,
+        "sharder_listen": "0.0.0.0",
+    }
 
-  return c
+    return c
 
 
 # configure_database takes a yaml "config" data set
@@ -29,47 +30,50 @@ def default_config():
 # or an in-memory database (used only for testing).
 def configure_database(config, log):
     # Determine the database engine.
-    db_type = os.environ.get('DB_TYPE')
-    if db_type is None and 'db_type' in config:
-      db_type = config['db_type']
+    db_type = os.environ.get("DB_TYPE")
+    if db_type is None and "db_type" in config:
+        db_type = config["db_type"]
 
     # PostgreSQL and MySQL support
-    if db_type == 'postgresql' or db_type == 'mysql+pymysql':
+    if db_type == "postgresql" or db_type == "mysql+pymysql":
         # Support credentials both in the config file and in the environment.
-        username = os.environ.get('DB_USER')
-        if username is None and 'db_user' in config:
-          username = config['db_user']
+        username = os.environ.get("DB_USER")
+        if username is None and "db_user" in config:
+            username = config["db_user"]
 
-        password = os.environ.get('DB_PASSWORD')
-        if password is None and 'db_password' in config:
-          password = config['db_password']
+        password = os.environ.get("DB_PASSWORD")
+        if password is None and "db_password" in config:
+            password = config["db_password"]
 
-        db_host = os.environ.get('DB_HOST')
-        if db_host is None and 'db_name' in config:
-          db_host = config['db_host']
+        db_host = os.environ.get("DB_HOST")
+        if db_host is None and "db_name" in config:
+            db_host = config["db_host"]
 
-        db_name = os.environ.get('DB_NAME')
-        if db_name is None and 'db_name' in config:
-          db_name = config['db_name']
+        db_name = os.environ.get("DB_NAME")
+        if db_name is None and "db_name" in config:
+            db_name = config["db_name"]
 
-        engine = create_engine(f'{db_type}://{username}:{password}@{db_host}/{db_name}', connect_args={'connect_timeout': 10})
-        log.info(f'{db_type} DB init')
+        engine = create_engine(
+            f"{db_type}://{username}:{password}@{db_host}/{db_name}",
+            connect_args={"connect_timeout": 10},
+        )
+        log.info(f"{db_type} DB init")
 
         return engine
 
     # SQLite
-    db_file = os.environ.get('DB_FILE')
-    if db_file is None and 'db_file' in config:
-      db_file = config['db_file']
+    db_file = os.environ.get("DB_FILE")
+    if db_file is None and "db_file" in config:
+        db_file = config["db_file"]
 
     if db_file is not None:
-      engine = create_engine(f'sqlite:///{db_file}')
+        engine = create_engine(f"sqlite:///{db_file}")
     else:
-      # in-memory sqlite db for testing.
-      creator = lambda: sqlite3.connect('file::memory:?cache=shared', uri=True)
-      engine = create_engine('sqlite://', creator=creator, echo=True)
+        # in-memory sqlite db for testing.
+        creator = lambda: sqlite3.connect("file::memory:?cache=shared", uri=True)
+        engine = create_engine("sqlite://", creator=creator, echo=True)
 
-    log.info(f'Sqlite3 DB init')
+    log.info(f"Sqlite3 DB init")
 
     return engine
 
@@ -79,9 +83,9 @@ def configure_database(config, log):
 def create_sharder(config, engine, log):
     # Get the list of hubs in the cluster.
     hubs = []
-    if 'hubs' in config:
-      hubs = config['hubs']
+    if "hubs" in config:
+        hubs = config["hubs"]
 
-    sharder = Sharder(engine, 'hub', hubs, log)
+    sharder = Sharder(engine, "hub", hubs, log)
 
     return sharder


### PR DESCRIPTION
We'd like to be able to influence the sharding decisions, so we're adding an `extra_shards` attribute to the hub configuration. When running the sharding code, that effective bucket count will be the actual bucket count plus any `extra_shards` for that bucket. This will let us manipulate sharding decisions as needed.